### PR TITLE
Add media display to Waybar

### DIFF
--- a/home/.config/meowrch/themes/catppuccin-latte/waybar.css
+++ b/home/.config/meowrch/themes/catppuccin-latte/waybar.css
@@ -109,6 +109,7 @@ tooltip {
 
 #tray,
 #workspaces,
+#custom-media,
 #taskbar,
 #clock,
 #idle_inhibitor,
@@ -161,4 +162,11 @@ tooltip {
 #custom-padd_bg {
     background: @main-bg;
     margin: 4px 0px 4px 0px;
+}
+
+#custom-media {
+    background: @main-bg;
+	border-radius: 20px;
+	margin: 4px 0px 4px 0px;
+    padding: 0px 20px 0px 20px;
 }

--- a/home/.config/meowrch/themes/catppuccin-latte/waybar.jsonc
+++ b/home/.config/meowrch/themes/catppuccin-latte/waybar.jsonc
@@ -11,7 +11,7 @@
     //==> Modules Layout
     ///////////////////////////////////////////////////////////////
 	"modules-left": [
-		"custom/l_end","tray","custom/r_end","custom/l_end","hyprland/workspaces","custom/r_end","custom/l_end","wlr/taskbar","custom/r_end","custom/padd"
+		"custom/l_end","tray","custom/r_end","custom/l_end","hyprland/workspaces","custom/r_end","custom/l_end","wlr/taskbar","custom/r_end","custom/media","custom/padd"
 	],
 	"modules-center": [
 		"group/system-info"
@@ -191,6 +191,16 @@
 	    "scroll-step": 5,
         "tooltip": false
 	},
+    "custom/media": {
+        "format": "{text}",
+        "format-alt": "{}",
+        "exec": "~/bin/media.sh",
+        "interval": 1,
+        "rotate": 0,
+        "return-type": "json",
+        "on-click": "playerctl play-pause",
+        "on-click-right": "playerctl next"
+    },
 	"hyprland/language": {
         "format": "{short} {variant}",
         "rotate": 0,

--- a/home/.config/meowrch/themes/catppuccin-mocha/waybar.css
+++ b/home/.config/meowrch/themes/catppuccin-mocha/waybar.css
@@ -109,6 +109,7 @@ tooltip {
 
 #tray,
 #workspaces,
+#custom-media,
 #taskbar,
 #clock,
 #idle_inhibitor,
@@ -160,4 +161,11 @@ tooltip {
 #custom-padd_bg {
     background: @main-bg;
     margin: 4px 0px 4px 0px;
+}
+
+#custom-media {
+    background: @main-bg;
+	border-radius: 20px;
+	margin: 4px 0px 4px 0px;
+    padding: 0px 20px 0px 20px;
 }

--- a/home/.config/meowrch/themes/catppuccin-mocha/waybar.jsonc
+++ b/home/.config/meowrch/themes/catppuccin-mocha/waybar.jsonc
@@ -11,7 +11,7 @@
     //==> Modules Layout
     ///////////////////////////////////////////////////////////////
 	"modules-left": [
-		"custom/l_end","tray","custom/r_end","custom/l_end","hyprland/workspaces","custom/r_end","custom/l_end","wlr/taskbar","custom/r_end","custom/padd"
+		"custom/l_end","tray","custom/r_end","custom/l_end","hyprland/workspaces","custom/r_end","custom/l_end","wlr/taskbar","custom/r_end","custom/media","custom/padd"
 	],
 	"modules-center": [
 		"group/system-info"
@@ -50,7 +50,7 @@
 			"custom/power"
 		]
 	},
-        
+
     //==> Left Modules
     ///////////////////////////////////////////////////////////////
     "tray": {
@@ -86,7 +86,7 @@
 
     //==> Middle Modules
     ///////////////////////////////////////////////////////////////
-    "custom/cpu": {
+	"custom/cpu": {
 		"exec": "python ~/bin/system-info.py --cpu --normal-color \"#f5c2e7\" --critical-color \"#f38ba8\" | cat",
 		"on-click": "python ~/bin/system-info.py --cpu --click",
 		"return-type": "json",
@@ -192,6 +192,16 @@
 	    "scroll-step": 5,
         "tooltip": false
 	},
+    "custom/media": {
+        "format": "{text}",
+        "format-alt": "{}",
+        "exec": "~/bin/media.sh",
+        "interval": 1,
+        "rotate": 0,
+        "return-type": "json",
+        "on-click": "playerctl play-pause",
+        "on-click-right": "playerctl next"
+    },
 	"hyprland/language": {
         "format": "{short} {variant}",
         "rotate": 0,

--- a/home/bin/media.sh
+++ b/home/bin/media.sh
@@ -1,6 +1,16 @@
 #!/bin/bash
 
-# Get media's metadata
+# Escape JSON (use Python for safety)
+json_escape() {
+  echo -n "$1" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))'
+}
+
+# Escape HTML for GTK markup
+html_escape() {
+  echo "$1" | sed 's/&/\&amp;/g; s/</\&lt;/g; s/>/\&gt;/g; s/\"/\&quot;/g; s/'"'"'/\&#39;/g'
+}
+
+# Get information
 title=$(playerctl metadata title 2>/dev/null)
 artist=$(playerctl metadata artist 2>/dev/null)
 
@@ -10,11 +20,23 @@ if [ -z "$title" ]; then
   exit 0
 fi
 
-# Shorten title if longer than 20 characters
-short_title=$title
-if [ ${#title} -gt 20 ]; then
-  short_title="${title:0:20}..."
-fi
+# Truncate
+truncate_text() {
+  local text="$1"
+  local max_length="$2"
+  if [ ${#text} -gt $max_length ]; then
+    echo "${text:0:max_length}…"
+  else
+    echo "$text"
+  fi
+}
 
-# Returns JSON
-echo "{\"text\": \"  $short_title\", \"tooltip\": \"$artist - $title\"}"
+short_title=$(truncate_text "$title" 10)
+short_artist=$(truncate_text "$artist" 10)
+
+# Escape text for GTK Markup (must use HTML_escape)
+escaped_display=$(html_escape "  $short_title | $short_artist")
+escaped_tooltip=$(json_escape "$title — $artist")  # Tooltip is still JSON should use json_escape
+
+# JSON export
+echo "{\"text\": \"$escaped_display\", \"tooltip\": $escaped_tooltip}"

--- a/home/bin/media.sh
+++ b/home/bin/media.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Get media's metadata
+title=$(playerctl metadata title 2>/dev/null)
+artist=$(playerctl metadata artist 2>/dev/null)
+
+# If there is no media playing, display "No media"
+if [ -z "$title" ]; then
+  echo '{"text": "  No media", "tooltip": ""}'
+  exit 0
+fi
+
+# Shorten title if longer than 20 characters
+short_title=$title
+if [ ${#title} -gt 20 ]; then
+  short_title="${title:0:20}..."
+fi
+
+# Returns JSON
+echo "{\"text\": \"  $short_title\", \"tooltip\": \"$artist - $title\"}"

--- a/home/bin/media.sh
+++ b/home/bin/media.sh
@@ -1,26 +1,16 @@
 #!/bin/bash
 
-# Escape JSON (use Python for safety)
+# Escape JSON safely
 json_escape() {
   echo -n "$1" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))'
 }
 
-# Escape HTML for GTK markup
+# Escape for GTK markup
 html_escape() {
   echo "$1" | sed 's/&/\&amp;/g; s/</\&lt;/g; s/>/\&gt;/g; s/\"/\&quot;/g; s/'"'"'/\&#39;/g'
 }
 
-# Get information
-title=$(playerctl metadata title 2>/dev/null)
-artist=$(playerctl metadata artist 2>/dev/null)
-
-# If there is no media playing, display "No media"
-if [ -z "$title" ]; then
-  echo '{"text": "  No media", "tooltip": ""}'
-  exit 0
-fi
-
-# Truncate
+# Truncate safely
 truncate_text() {
   local text="$1"
   local max_length="$2"
@@ -31,12 +21,96 @@ truncate_text() {
   fi
 }
 
-short_title=$(truncate_text "$title" 10)
-short_artist=$(truncate_text "$artist" 10)
+# Normalize for comparison
+normalize() {
+  echo "$1" | tr '[:upper:]' '[:lower:]' | sed 's/([^)]*)//g' | sed 's/^[[:space:]]*//; s/[[:space:]]*$//'
+}
 
-# Escape text for GTK Markup (must use HTML_escape)
-escaped_display=$(html_escape "  $short_title | $short_artist")
-escaped_tooltip=$(json_escape "$title — $artist")  # Tooltip is still JSON should use json_escape
+# Find which media is "Playing"
+active_media=$(playerctl -l 2>/dev/null | while read -r player; do
+  status=$(playerctl -p "$player" status 2>/dev/null)
+  if [ "$status" = "Playing" ]; then
+    echo "$player"
+    break
+  fi
+done)
 
-# JSON export
+if [ -z "$active_media" ]; then
+  echo '{"text": "  No media", "tooltip": ""}'
+  exit 0
+fi
+
+# Get metadata from the current playing media
+title=$(playerctl -p "$active_media" metadata title 2>/dev/null)
+artist=$(playerctl -p "$active_media" metadata artist 2>/dev/null)
+
+
+# If there is no title, escape early
+if [ -z "$title" ]; then
+  echo '{"text": "  No media", "tooltip": ""}'
+  exit 0
+fi
+
+# Find the title containing the separation
+if [[ "$title" == *"｜"* || "$title" == *"|"* || "$title" == *"-"* ]]; then
+  # Separate
+  if [[ "$title" == *"｜"* ]]; then
+    IFS='｜' read -r part1 part2 <<< "$title"
+  elif [[ "$title" == *"|"* ]]; then
+    IFS='|' read -r part1 part2 <<< "$title"
+  else
+    IFS='-' read -r part1 part2 <<< "$title"
+  fi
+
+  part1=$(echo "$part1" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')
+  part2=$(echo "$part2" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')
+
+  # Normalize text to compared to metadata artist
+  norm_part1=$(normalize "$part1")
+  norm_part2=$(normalize "$part2")
+  norm_artist=$(normalize "$artist")
+
+  if [[ "$norm_part1" == "$norm_artist"* ]]; then
+    artist="$part1"
+    title="$part2"
+  elif [[ "$norm_part2" == "$norm_artist"* ]]; then
+    artist="$part2"
+    title="$part1"
+  else
+    # If not clear, keep the order, Part1 is Artist
+    artist="$part2"
+    title="$part1"
+  fi
+else
+  # If there is no separation mark and artist is still empty
+  if [ -z "$artist" ]; then
+    artist=""
+  fi
+fi
+
+# If it is still a unknown artist, use fallback
+if [ -z "$artist" ]; then
+  if [[ "$title" == *"｜"* ]]; then
+    artist=$(echo "$title" | awk -F '｜' '{print $1}' | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')
+    title=$(echo "$title" | awk -F '｜' '{$1=""; sub(/^ /,""); print}' | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')
+  elif [[ "$title" == *"-"* ]]; then
+    artist=$(echo "$title" | awk -F '-' '{print $1}' | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')
+    title=$(echo "$title" | awk -F '-' '{$1=""; sub(/^ /,""); print}' | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')
+  fi
+fi
+
+# Create a display text
+if [ -n "$artist" ]; then
+  short_title=$(truncate_text "$title" 15)
+  short_artist=$(truncate_text "$artist" 10)
+  display_text="  $short_title | $short_artist"
+else
+  short_title=$(truncate_text "$title" 25)
+  display_text="  $short_title"
+fi
+
+# Escape and export
+escaped_display=$(html_escape "$display_text")
+escaped_tooltip=$(json_escape "$title — $artist")
+
 echo "{\"text\": \"$escaped_display\", \"tooltip\": $escaped_tooltip}"


### PR DESCRIPTION
## Changes included:

- home/bin/media.sh: Bash script to get and format media metadata.
- Updates to waybar.jsonc for both latte and mocha themes to include the custom/media module.
- Matching CSS added to waybar.css for consistent visual integration.

## Preview:

### Latte

![image](https://github.com/user-attachments/assets/0a8d77cc-e669-4f3d-8938-f661b9df604d)

![image](https://github.com/user-attachments/assets/bf77878e-e45c-473d-88df-21b16f18799e)

### Mocha

![image](https://github.com/user-attachments/assets/a25f5647-fe62-40f5-9488-6f8f8fba5dfb)

![image](https://github.com/user-attachments/assets/943da0c2-1e98-4b6f-a0e5-0e036ccbb3d7)
